### PR TITLE
Updated joe's hero list

### DIFF
--- a/data/heroes/joe.json
+++ b/data/heroes/joe.json
@@ -1,11 +1,14 @@
 [
-	"Abaddon", 
-	"Legion Commander", 
-	"Axe", 
-	"Slardar", 
-	"Underlord", 
-	"Dark Seer", 
-	"Dragon Knight", 
-	"Tidehunter", 
-	"Bristleback"
+	"Abaddon",
+	"Axe",
+	"Bristleback",
+	"Dark Seer",
+	"Dragon Knight",
+	"Legion Commander",
+	"Magnus",
+	"Slardar",
+	"Tidehunter",
+	"Timbersaw",
+	"Underlord",
+	"Undying"
 ]


### PR DESCRIPTION
These changes add the heroes `Magnus`, `Timbersaw`, and `Undying` to Joe's hero pool. It also alphabetizes the list since that was annoying me.